### PR TITLE
upgrade sdm and add github status goals to default machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,8 +226,9 @@
       "integrity": "sha512-RtdJA8QodmVchEdWDvLOaeYrASU8Y12/pFHqDOXkGyjgmP+svZaHL2YEdGDjy++ArVL3lpCNXG7ZPYPjVKTugQ=="
     },
     "@atomist/sdm": {
-      "version": "https://r.atomist.com/ryIgRHtl4yX",
-      "integrity": "sha512-MpWbi9jgBoVvLMQpBs2BzZXnjdkEupLHdico4jStAOsORIO2h3bH40j0NG0b6wGox8zp5BrSvDFJZjuENXzkzg==",
+      "version": "0.1.1-20180525014606",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-0.1.1-20180525014606.tgz",
+      "integrity": "sha512-Exun1gFd52KqB59f+bl86wJ7OXbFN2oAfuoaoQdtNDxKSn+zT+lXUKHhgRrDzkXq2smewyLyPDn9JXtyuDdYZg==",
       "requires": {
         "@atomist/automation-client": "https://r.atomist.com/BJxzuM1V20G",
         "@atomist/slack-messages": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@atomist/automation-client": "https://r.atomist.com/BJxzuM1V20G",
-    "@atomist/sdm": "https://r.atomist.com/ryIgRHtl4yX",
+    "@atomist/sdm": "0.1.1-20180525014606",
     "@atomist/slack-messages": "^0.12.1",
     "@atomist/spring-automation": "https://r.atomist.com/S1E-JulqWJQ",
     "@commitlint/config-conventional": "^6.1.3",

--- a/src/machines/cloudFoundryMachine.ts
+++ b/src/machines/cloudFoundryMachine.ts
@@ -37,11 +37,11 @@ import {
     StagingDeploymentGoal,
     StagingEndpointGoal,
     StagingUndeploymentGoal,
+    summarizeGoalsInGitHubStatus,
     ToDefaultBranch,
     ToPublicRepo,
     UndeployEverywhereGoals,
     whenPushSatisfies,
-    summarizeGoalsInGitHubStatus,
 } from "@atomist/sdm";
 import * as build from "@atomist/sdm/blueprint/dsl/buildDsl";
 import * as deploy from "@atomist/sdm/blueprint/dsl/deployDsl";

--- a/src/machines/cloudFoundryMachine.ts
+++ b/src/machines/cloudFoundryMachine.ts
@@ -41,6 +41,7 @@ import {
     ToPublicRepo,
     UndeployEverywhereGoals,
     whenPushSatisfies,
+    summarizeGoalsInGitHubStatus,
 } from "@atomist/sdm";
 import * as build from "@atomist/sdm/blueprint/dsl/buildDsl";
 import * as deploy from "@atomist/sdm/blueprint/dsl/deployDsl";
@@ -181,6 +182,8 @@ export function cloudFoundryMachine(options: SoftwareDeliveryMachineOptions,
     addNodeSupport(sdm);
     addTeamPolicies(sdm, configuration);
     addDemoEditors(sdm);
+    summarizeGoalsInGitHubStatus(sdm);
+
     // addDemoPolicies(sdm, configuration);
     return sdm;
 }


### PR DESCRIPTION
We removed GitHub statuses from the sdm, so that way we can use it for bitbucket

this puts it only in the PCF machine but that's the default so it's useful. 