### PR TITLE
add node support to the additive machine for building

### DIFF
--- a/src/machines/additiveCloudFoundryMachine.ts
+++ b/src/machines/additiveCloudFoundryMachine.ts
@@ -16,6 +16,7 @@
 
 import { Configuration } from "@atomist/automation-client";
 import {
+    any,
     AnyPush,
     ArtifactGoal, goalContributors,
     Goals,
@@ -47,6 +48,7 @@ import { createEphemeralProgressLog } from "@atomist/sdm/log/EphemeralProgressLo
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
 import { SoftwareDeliveryMachineOptions } from "@atomist/sdm/machine/SoftwareDeliveryMachineOptions";
 import { IsMaven } from "@atomist/sdm/mapping/pushtest/jvm/jvmPushTests";
+import {IsNode} from "@atomist/sdm/mapping/pushtest/node/nodePushTests";
 import { HasCloudFoundryManifest } from "@atomist/sdm/mapping/pushtest/pcf/cloudFoundryManifestPushTest";
 import {
     deploymentFreeze,
@@ -91,7 +93,7 @@ export function additiveCloudFoundryMachine(options: SoftwareDeliveryMachineOpti
             onAnyPush.setGoals(new Goals("Checks", ReviewGoal, PushReactionGoal)),
             whenPushSatisfies(IsDeploymentFrozen)
                 .setGoals(ExplainDeploymentFreezeGoal),
-            whenPushSatisfies(IsMaven)
+            whenPushSatisfies(any(IsMaven, IsNode))
                 .setGoals(JustBuildGoal),
             whenPushSatisfies(HasSpringBootApplicationClass, not(ToDefaultBranch))
                 .setGoals(LocalDeploymentGoal),
@@ -123,10 +125,6 @@ export function additiveCloudFoundryMachine(options: SoftwareDeliveryMachineOpti
         CloudReadinessChecks,
         NodeSupport,
     );
-
-    sdm.addBuildRules(
-        build.setDefault(new MavenBuilder(options.artifactStore,
-            createEphemeralProgressLog, options.projectLoader)));
 
     sdm.addDeployRules(
         deploy.when(IsMaven)
@@ -161,6 +159,10 @@ export function additiveCloudFoundryMachine(options: SoftwareDeliveryMachineOpti
     addTeamPolicies(sdm);
     addDemoEditors(sdm);
     // addDemoPolicies(sdm, configuration);
+
+    sdm.addBuildRules(
+        build.setDefault(new MavenBuilder(options.artifactStore,
+            createEphemeralProgressLog, options.projectLoader)));
 
     return sdm;
 }


### PR DESCRIPTION

Node support is needed for the smoke test nodeBuild.feature and it seems like a regression that node projects are no longer built with the addivie machine. There is likely more node support that is missing. For deployment for example.

I noticed that addBuildRules is now deprecated, but I don't know what else to use, and it is still used when configuring the machine.

build.setDefault for the MavenBuilder was moved to the end because order seems to matter here. If it is set first, then it will always execute because of the overly permissive AnyPush test that default is automatically given. It resulted in the node build rules that I added never firing. This seems like a flaw with setDefault or the goal implementation mapper. These defaults need to be ordered at the end of the implementations or be handled differently than the when implementations. This seems like a gotcha that would make build rule firing unnecessarily confusing.

added a generator for a buildable node seed that could be used in the smoke test that will actually build and fail. The minimal-node-seed doesn't actually build and will never fail.