### PR TITLE
Move SDM options into client's configuration object 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -235,8 +235,8 @@
       "integrity": "sha512-ZbiZTTEPEWu/WrloPlnfG0+8Zr0mJZXeLaCb6EneZ2RZOZyfedVfxEUReJMJkLGyC9RXxvra6rAf847rebZTTw=="
     },
     "@atomist/sdm": {
-      "version": "https://r.atomist.com/HyIlQ3St017",
-      "integrity": "sha512-sD/RKJTkaqNT2HXrNo53zsNb0pWlnbLDBNkPMMny1QevmncvYMEDH+LcHE7CXkar9JoIvE1miPOPW0Z88nTf+Q==",
+      "version": "https://r.atomist.com/SkQlHyB0Ry7",
+      "integrity": "sha512-FawPJXkWvCcfZkCYz4Rco9SSsxCrpeVhUOR307GUZ8RzZepPSsKdLyBya0mCZZMIfpfQPbTKB48EBvwSmtrHEQ==",
       "requires": {
         "@atomist/automation-client": "https://r.atomist.com/Sy40CNL2ym",
         "@atomist/slack-messages": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@atomist/automation-client": "https://r.atomist.com/Sy40CNL2ym",
-    "@atomist/sdm": "https://r.atomist.com/HyIlQ3St017",
+    "@atomist/sdm": "https://r.atomist.com/SkQlHyB0Ry7",
     "@atomist/slack-messages": "^0.12.1",
     "@atomist/spring-automation": "https://r.atomist.com/BJg-zHykFyQ",
     "@commitlint/config-conventional": "^6.1.3",

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -87,5 +87,5 @@ export const configuration: Configuration = {
     ],
     sdm: {
         artifactStore: null,
-    }
+    },
 };

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -85,7 +85,4 @@ export const configuration: Configuration = {
         configureLogzio,
         configureSdm(machineMaker, Options),
     ],
-    sdm: {
-        artifactStore: null,
-    },
 };

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -15,9 +15,11 @@
  */
 
 import { Configuration } from "@atomist/automation-client";
-import { SoftwareDeliveryMachine, SoftwareDeliveryMachineOptions } from "@atomist/sdm";
-import { ConfigureOptions, configureSdm } from "@atomist/sdm/internal/machine/configureSdm";
-import { tryRolarLogFactory } from "./blueprint/log/logFactory";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
+import {
+    ConfigureOptions,
+    configureSdm,
+} from "@atomist/sdm/internal/machine/configureSdm";
 import { additiveCloudFoundryMachine } from "./machines/additiveCloudFoundryMachine";
 import { configureLogzio } from "./util/logzio";
 
@@ -51,9 +53,8 @@ import { configureLogzio } from "./util/logzio";
  * start with any of these and change it to make it your own!
  */
 
-function createMachine(options: SoftwareDeliveryMachineOptions,
-                       config: Configuration): SoftwareDeliveryMachine {
-    return additiveCloudFoundryMachine(options, config);
+function machineMaker(config: SoftwareDeliveryMachineConfiguration) {
+    return additiveCloudFoundryMachine(config);
 }
 
 const Options: ConfigureOptions = {
@@ -65,10 +66,6 @@ const Options: ConfigureOptions = {
         "sdm.cloudfoundry.spaces.production",
         "sdm.cloudfoundry.spaces.staging",
     ],
-    sdmOptions: {
-        // TODO get this from the config
-        logFactory: tryRolarLogFactory("http://rolar.cfapps.io"),
-    },
 };
 
 export const configuration: Configuration = {
@@ -81,14 +78,14 @@ export const configuration: Configuration = {
             },
         },
     },
-    cluster: {
-        workers: 1,
-    },
     logging: {
         level: "info",
     },
     postProcessors: [
         configureLogzio,
-        configureSdm(createMachine, Options),
+        configureSdm(machineMaker, Options),
     ],
+    sdm: {
+        artifactStore: null,
+    }
 };

--- a/src/blueprint/code/autofix/addAtomistHeader.ts
+++ b/src/blueprint/code/autofix/addAtomistHeader.ts
@@ -15,15 +15,18 @@
  */
 
 import {
+    allSatisfied,
     AutofixRegistration,
     editorAutofixRegistration,
+    hasFileContaining,
+    PushTest,
 } from "@atomist/sdm";
-import { PushTest } from "@atomist/sdm";
-import { hasFileContaining } from "@atomist/sdm";
-import { allSatisfied } from "@atomist/sdm";
 import { IsJava } from "@atomist/sdm/mapping/pushtest/jvm/jvmPushTests";
 import { IsTypeScript } from "@atomist/sdm/mapping/pushtest/node/tsPushTests";
-import { AddHeaderParameters, addHeaderProjectEditor } from "../../../commands/editors/license/addHeader";
+import {
+    AddHeaderParameters,
+    addHeaderProjectEditor,
+} from "../../../commands/editors/license/addHeader";
 import { LicenseFilename } from "./addLicenseFile";
 
 export const AddAtomistJavaHeader: AutofixRegistration = addAtomistHeader("Java header", "**/*.java", IsJava);

--- a/src/blueprint/code/autofix/addLicenseFile.ts
+++ b/src/blueprint/code/autofix/addLicenseFile.ts
@@ -17,9 +17,9 @@
 import {
     AutofixRegistration,
     editorAutofixRegistration,
+    hasFile,
+    not,
 } from "@atomist/sdm";
-import { hasFile } from "@atomist/sdm";
-import { not } from "@atomist/sdm";
 import axios from "axios";
 
 export const LicenseFilename = "LICENSE";

--- a/src/blueprint/code/review/java/maven/providedDependencyReviewer.ts
+++ b/src/blueprint/code/review/java/maven/providedDependencyReviewer.ts
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-import { DefaultReviewComment, ReviewComment } from "@atomist/automation-client/operations/review/ReviewResult";
+import {
+    DefaultReviewComment,
+    ReviewComment,
+} from "@atomist/automation-client/operations/review/ReviewResult";
 import { File } from "@atomist/automation-client/project/File";
 import { Project } from "@atomist/automation-client/project/Project";
 import { ReviewerRegistration } from "@atomist/sdm";
-import { promisify } from "util";
-import * as xml2js from "xml2js";
 
 import { IsMaven } from "@atomist/sdm/mapping/pushtest/jvm/jvmPushTests";
 import * as _ from "lodash";
+import { promisify } from "util";
+import * as xml2js from "xml2js";
 
 export const ProvidedDependencyCategory = "Use of `provided` dependencies in Maven POM";
 

--- a/src/blueprint/code/review/java/spring/hardcodedPropertyReviewer.ts
+++ b/src/blueprint/code/review/java/spring/hardcodedPropertyReviewer.ts
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-import { DefaultReviewComment, ReviewComment } from "@atomist/automation-client/operations/review/ReviewResult";
+import { logger } from "@atomist/automation-client";
+import {
+    DefaultReviewComment,
+    ReviewComment,
+} from "@atomist/automation-client/operations/review/ReviewResult";
 import { File } from "@atomist/automation-client/project/File";
 import { Project } from "@atomist/automation-client/project/Project";
 import { saveFromFilesAsync } from "@atomist/automation-client/project/util/projectUtils";
 import { ReviewerRegistration } from "@atomist/sdm";
+import * as _ from "lodash";
 
 import * as props from "properties-reader";
-
-import { logger } from "@atomist/automation-client";
-import * as _ from "lodash";
 import { HasSpringPom } from "../../../../../pack/spring/pushtest/springPushTests";
 
 const PropertyKeysToCheck = [

--- a/src/blueprint/deploy/cloudFoundryDeploy.ts
+++ b/src/blueprint/deploy/cloudFoundryDeploy.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { DeployerInfo, ProjectLoader, PushImpactListener, PushReactionRegistration } from "@atomist/sdm";
+import {
+    DeployerInfo,
+    ProjectLoader,
+    PushImpactListener,
+    PushReactionRegistration,
+} from "@atomist/sdm";
 import { setDeployEnablement } from "@atomist/sdm/handlers/commands/SetDeployEnablement";
 import { CloudFoundryBlueGreenDeployer } from "@atomist/sdm/pack/pcf/CloudFoundryBlueGreenDeployer";
 import { CloudFoundryInfo } from "@atomist/sdm/pack/pcf/CloudFoundryTarget";

--- a/src/blueprint/deploy/localSpringBootDeployers.ts
+++ b/src/blueprint/deploy/localSpringBootDeployers.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { Deployer, ProjectLoader } from "@atomist/sdm";
+import {
+    Deployer,
+    ProjectLoader,
+} from "@atomist/sdm";
 import { executableJarDeployer } from "@atomist/sdm/internal/delivery/deploy/local/jar/executableJarDeployer";
 import { StartupInfo } from "@atomist/sdm/internal/delivery/deploy/local/LocalDeployerOptions";
 import { ManagedDeploymentTargetInfo } from "@atomist/sdm/internal/delivery/deploy/local/ManagedDeployments";

--- a/src/blueprint/issue/issueManagingReviewListeners.ts
+++ b/src/blueprint/issue/issueManagingReviewListeners.ts
@@ -23,14 +23,17 @@ import {
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { ReviewComment } from "@atomist/automation-client/operations/review/ReviewResult";
 import { Issue } from "@atomist/automation-client/util/gitHub";
-import { ReviewListener, ReviewListenerInvocation } from "@atomist/sdm";
-import Push = OnPushToAnyBranch.Push;
+import {
+    ReviewListener,
+    ReviewListenerInvocation,
+} from "@atomist/sdm";
 import { OnPushToAnyBranch } from "@atomist/sdm/typings/types";
 import { authHeaders } from "@atomist/sdm/util/github/ghub";
 import * as slack from "@atomist/slack-messages";
 import axios from "axios";
 import * as stringify from "json-stringify-safe";
 import * as _ from "lodash";
+import Push = OnPushToAnyBranch.Push;
 
 export type CommentFilter = (r: ReviewComment) => boolean;
 

--- a/src/blueprint/repo/suggestAddingCloudFoundryManifest.ts
+++ b/src/blueprint/repo/suggestAddingCloudFoundryManifest.ts
@@ -16,9 +16,12 @@
 
 import { logger } from "@atomist/automation-client";
 import { buttonForCommand } from "@atomist/automation-client/spi/message/MessageClient";
-import { ChannelLinkListener } from "@atomist/sdm";
-import { ProjectPredicate } from "@atomist/sdm";
-import { allPredicatesSatisfied, anyPredicateSatisfied } from "@atomist/sdm";
+import {
+    allPredicatesSatisfied,
+    anyPredicateSatisfied,
+    ChannelLinkListener,
+    ProjectPredicate,
+} from "@atomist/sdm";
 import { IsMaven } from "@atomist/sdm/mapping/pushtest/jvm/jvmPushTests";
 import { IsNode } from "@atomist/sdm/mapping/pushtest/node/nodePushTests";
 import * as slack from "@atomist/slack-messages/SlackMessages";

--- a/src/commands/editors/demo/affirmationEditor.ts
+++ b/src/commands/editors/demo/affirmationEditor.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { Parameter, Parameters } from "@atomist/automation-client";
+import {
+    Parameter,
+    Parameters,
+} from "@atomist/automation-client";
 import { SimpleProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { doWithFiles } from "@atomist/automation-client/project/util/projectUtils";
 import { EditorRegistration } from "@atomist/sdm";

--- a/src/commands/editors/demo/javaAffirmationEditor.ts
+++ b/src/commands/editors/demo/javaAffirmationEditor.ts
@@ -18,7 +18,10 @@ import { SimpleProjectEditor } from "@atomist/automation-client/operations/edit/
 import { doWithFiles } from "@atomist/automation-client/project/util/projectUtils";
 import { EditorRegistration } from "@atomist/sdm";
 import { AllJavaFiles } from "@atomist/spring-automation/commands/generator/java/javaProjectUtils";
-import { AffirmationParameters, affirmations } from "./affirmationEditor";
+import {
+    AffirmationParameters,
+    affirmations,
+} from "./affirmationEditor";
 
 const appendAffirmationToJava: SimpleProjectEditor<AffirmationParameters> = (p, ctx, params) => {
     const affirmation = params.customAffirmation || randomAffirmation();

--- a/src/commands/editors/helper/removeFile.ts
+++ b/src/commands/editors/helper/removeFile.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { HandlerContext, Parameter } from "@atomist/automation-client";
+import {
+    HandlerContext,
+    Parameter,
+} from "@atomist/automation-client";
 import { Parameters } from "@atomist/automation-client/decorators";
 import { commitToMaster } from "@atomist/automation-client/operations/edit/editModes";
 import { Project } from "@atomist/automation-client/project/Project";

--- a/src/commands/editors/k8s/k8sSpecPushTest.ts
+++ b/src/commands/editors/k8s/k8sSpecPushTest.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { PredicatePushTest, predicatePushTest } from "@atomist/sdm";
+import {
+    PredicatePushTest,
+    predicatePushTest,
+} from "@atomist/sdm";
 import { AtomistK8sSpecFile } from "./addK8sSpec";
 
 export const HasK8Spec: PredicatePushTest = predicatePushTest(

--- a/src/commands/editors/license/addHeader.ts
+++ b/src/commands/editors/license/addHeader.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { HandlerContext, logger, Parameter, Parameters } from "@atomist/automation-client";
+import {
+    HandlerContext,
+    logger,
+    Parameter,
+    Parameters,
+} from "@atomist/automation-client";
 import { File } from "@atomist/automation-client/project/File";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
 import { Project } from "@atomist/automation-client/project/Project";

--- a/src/commands/editors/support/RequestedCommitParameters.ts
+++ b/src/commands/editors/support/RequestedCommitParameters.ts
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-import { Parameter, Parameters } from "@atomist/automation-client";
+import {
+    Parameter,
+    Parameters,
+} from "@atomist/automation-client";
 import { GitBranchRegExp } from "@atomist/automation-client/operations/common/params/gitHubPatterns";
-import { BranchCommit, EditMode, PullRequest } from "@atomist/automation-client/operations/edit/editModes";
+import {
+    BranchCommit,
+    EditMode,
+    PullRequest,
+} from "@atomist/automation-client/operations/edit/editModes";
 
 /**
  * Allow user to specify a branch (with default master).

--- a/src/commands/editors/updateReadmeTitle.ts
+++ b/src/commands/editors/updateReadmeTitle.ts
@@ -15,9 +15,9 @@
  */
 
 import { doWithFileMatches } from "@atomist/automation-client/project/util/parseUtils";
-import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
 
 import { RestOfLine } from "@atomist/microgrammar/matchers/skip/Skip";
+import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
 
 export function updateReadmeTitle(appName: string,
                                   description: string) {

--- a/src/commands/generators/common/findAuthorName.ts
+++ b/src/commands/generators/common/findAuthorName.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { HandlerContext } from "@atomist/automation-client";
-import { logger } from "@atomist/automation-client";
+import {
+    HandlerContext,
+    logger,
+} from "@atomist/automation-client";
 import { PersonByChatId } from "@atomist/sdm/typings/types";
 
 /**

--- a/src/local/machine/LocalSoftwareDeliveryMachine.ts
+++ b/src/local/machine/LocalSoftwareDeliveryMachine.ts
@@ -1,8 +1,14 @@
-import { Configuration, HandleCommand, HandleEvent, logger } from "@atomist/automation-client";
+import {
+    Configuration,
+    HandleCommand,
+    HandleEvent,
+    logger,
+} from "@atomist/automation-client";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import {
     Builder,
-    CommandHandlerRegistration, DeploymentListener,
+    CommandHandlerRegistration,
+    DeploymentListener,
     EditorRegistration,
     enrichGoalSetters,
     ExecuteGoalWithLog,
@@ -13,16 +19,17 @@ import {
     GoalSetter,
     InterpretLog,
     PushMapping,
-    PushRule, PushRules,
+    PushRule,
+    PushRules,
     PushTest,
     SdmGoalImplementationMapper,
     SoftwareDeliveryMachine,
-    SoftwareDeliveryMachineOptions,
     StaticPushMapping,
     Target,
 } from "@atomist/sdm";
 import { ListenerRegistrationManagerSupport } from "@atomist/sdm/api-helper/machine/ListenerRegistrationManagerSupport";
 import { RegistrationManagerSupport } from "@atomist/sdm/api-helper/machine/RegistrationManagerSupport";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import * as _ from "lodash";
 
 export class LocalSoftwareDeliveryMachine extends ListenerRegistrationManagerSupport implements SoftwareDeliveryMachine {
@@ -121,8 +128,7 @@ export class LocalSoftwareDeliveryMachine extends ListenerRegistrationManagerSup
     }
 
     constructor(public readonly name: string,
-                public readonly options: SoftwareDeliveryMachineOptions,
-                public readonly configuration: Configuration,
+                public readonly configuration: Configuration & SoftwareDeliveryMachineConfiguration,
                 goalSetters: Array<GoalSetter | GoalSetter[]>) {
         super();
         this.pushMap = new PushRules("Goal setters", _.flatten(goalSetters));

--- a/src/machines/additiveCloudFoundryMachine.ts
+++ b/src/machines/additiveCloudFoundryMachine.ts
@@ -31,7 +31,6 @@ import {
     PushReactionGoal,
     ReviewGoal,
     SoftwareDeliveryMachine,
-    SoftwareDeliveryMachineOptions,
     StagingDeploymentGoal,
     StagingEndpointGoal,
     StagingVerifiedGoal,
@@ -39,12 +38,19 @@ import {
     whenPushSatisfies,
 } from "@atomist/sdm";
 import { createEphemeralProgressLog } from "@atomist/sdm/api-helper/log/EphemeralProgressLog";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import * as build from "@atomist/sdm/dsl/buildDsl";
 import * as deploy from "@atomist/sdm/dsl/deployDsl";
 import { StagingUndeploymentGoal } from "@atomist/sdm/goal/common/commonGoals";
-import { RepositoryDeletionGoals, UndeployEverywhereGoals } from "@atomist/sdm/goal/common/httpServiceGoals";
+import {
+    RepositoryDeletionGoals,
+    UndeployEverywhereGoals,
+} from "@atomist/sdm/goal/common/httpServiceGoals";
 import { isDeployEnabledCommand } from "@atomist/sdm/handlers/commands/DisplayDeployEnablement";
-import { disableDeploy, enableDeploy } from "@atomist/sdm/handlers/commands/SetDeployEnablement";
+import {
+    disableDeploy,
+    enableDeploy,
+} from "@atomist/sdm/handlers/commands/SetDeployEnablement";
 import { MavenBuilder } from "@atomist/sdm/internal/delivery/build/local/maven/MavenBuilder";
 import { ManagedDeploymentTargeter } from "@atomist/sdm/internal/delivery/deploy/local/ManagedDeployments";
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
@@ -82,12 +88,11 @@ const IsDeploymentFrozen = isDeploymentFrozen(freezeStore);
  * Variant of cloudFoundryMachine that uses additive, "contributor" style goal setting.
  * @return {SoftwareDeliveryMachine}
  */
-export function additiveCloudFoundryMachine(options: SoftwareDeliveryMachineOptions,
-                                            configuration: Configuration): SoftwareDeliveryMachine {
+export function additiveCloudFoundryMachine(configuration: SoftwareDeliveryMachineConfiguration): SoftwareDeliveryMachine {
     const sdm = createSoftwareDeliveryMachine(
         {
             name: "CloudFoundry software delivery machine",
-            options, configuration,
+            configuration,
         },
         // Each contributor contributes goals. The infrastructure assembles them into a goal set.
         goalContributors(
@@ -128,7 +133,7 @@ export function additiveCloudFoundryMachine(options: SoftwareDeliveryMachineOpti
         ),
         deploy.when(IsMaven)
             .deployTo(ProductionDeploymentGoal, ProductionEndpointGoal, ProductionUndeploymentGoal)
-            .using(cloudFoundryProductionDeploySpec(options)),
+            .using(cloudFoundryProductionDeploySpec(configuration.sdm)),
     );
     sdm.addDisposalRules(
         whenPushSatisfies(IsMaven, HasSpringBootApplicationClass, HasCloudFoundryManifest)
@@ -153,8 +158,8 @@ export function additiveCloudFoundryMachine(options: SoftwareDeliveryMachineOpti
     // sdm.addExtensionPacks(DemoPolicies);
 
     sdm.addBuildRules(
-        build.setDefault(new MavenBuilder(options.artifactStore,
-            createEphemeralProgressLog, options.projectLoader)));
+        build.setDefault(new MavenBuilder(configuration.sdm.artifactStore,
+            createEphemeralProgressLog, configuration.sdm.projectLoader)));
 
     return sdm;
 }

--- a/src/machines/additiveCloudFoundryMachine.ts
+++ b/src/machines/additiveCloudFoundryMachine.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Configuration } from "@atomist/automation-client";
 import {
     any,
     AnyPush,

--- a/src/machines/artifactVerifyingMachine.ts
+++ b/src/machines/artifactVerifyingMachine.ts
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-import { Configuration } from "@atomist/automation-client";
 import {
     ArtifactGoal,
     Goals,
     JustBuildGoal,
     SoftwareDeliveryMachine,
-    SoftwareDeliveryMachineOptions,
     whenPushSatisfies,
 } from "@atomist/sdm";
 import { createEphemeralProgressLog } from "@atomist/sdm/api-helper/log/EphemeralProgressLog";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import * as build from "@atomist/sdm/dsl/buildDsl";
 import { MavenBuilder } from "@atomist/sdm/internal/delivery/build/local/maven/MavenBuilder";
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
@@ -35,10 +34,9 @@ import { addDemoEditors } from "../parts/demo/demoEditors";
  * Assemble a machine that only builds and verifies Java artifacts.
  * @return {SoftwareDeliveryMachine}
  */
-export function artifactVerifyingMachine(options: SoftwareDeliveryMachineOptions,
-                                         configuration: Configuration): SoftwareDeliveryMachine {
+export function artifactVerifyingMachine(configuration: SoftwareDeliveryMachineConfiguration): SoftwareDeliveryMachine {
     const sdm = createSoftwareDeliveryMachine({
-            name: "Artifact verifying machine", options,
+            name: "Artifact verifying machine",
             configuration,
         }, whenPushSatisfies(IsMaven)
             .itMeans("Push to Maven repo")
@@ -47,7 +45,7 @@ export function artifactVerifyingMachine(options: SoftwareDeliveryMachineOptions
     sdm.addBuildRules(
         build.when(IsMaven)
             .itMeans("build with Maven")
-            .set(new MavenBuilder(options.artifactStore, createEphemeralProgressLog, options.projectLoader)))
+            .set(new MavenBuilder(configuration.sdm.artifactStore, createEphemeralProgressLog, configuration.sdm.projectLoader)))
         .addArtifactListeners(async ai => {
             // Could invoke a security scanning tool etc.
             const stat = fs.statSync(`${ai.deployableArtifact.cwd}/${ai.deployableArtifact.filename}`);

--- a/src/machines/autofixMachine.ts
+++ b/src/machines/autofixMachine.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-import { Configuration } from "@atomist/automation-client";
-import { AutofixGoal, Goals, onAnyPush, SoftwareDeliveryMachine, SoftwareDeliveryMachineOptions } from "@atomist/sdm";
+import {
+    AutofixGoal,
+    Goals,
+    onAnyPush,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
-import { AddAtomistJavaHeader, AddAtomistTypeScriptHeader } from "../blueprint/code/autofix/addAtomistHeader";
+import {
+    AddAtomistJavaHeader,
+    AddAtomistTypeScriptHeader,
+} from "../blueprint/code/autofix/addAtomistHeader";
 import { AddLicenseFile } from "../blueprint/code/autofix/addLicenseFile";
 import { addDemoEditors } from "../parts/demo/demoEditors";
 
@@ -25,9 +33,11 @@ import { addDemoEditors } from "../parts/demo/demoEditors";
  * Assemble a machine that performs only autofixes.
  * @return {SoftwareDeliveryMachine}
  */
-export function autofixMachine(options: SoftwareDeliveryMachineOptions,
-                               configuration: Configuration): SoftwareDeliveryMachine {
-    const sdm = createSoftwareDeliveryMachine({name: "Autofix machine", options, configuration},
+export function autofixMachine(configuration: SoftwareDeliveryMachineConfiguration): SoftwareDeliveryMachine {
+    const sdm = createSoftwareDeliveryMachine({
+            name: "Autofix machine",
+            configuration,
+        },
         onAnyPush
             .setGoals(new Goals("Autofix", AutofixGoal)));
     sdm.addAutofixes(

--- a/src/machines/evangelicalMachine.ts
+++ b/src/machines/evangelicalMachine.ts
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import { Configuration } from "@atomist/automation-client";
 import {
     executeSendMessageToSlack,
     MessageGoal,
     not,
-    SoftwareDeliveryMachine, SoftwareDeliveryMachineOptions,
+    SoftwareDeliveryMachine,
     ToDefaultBranch,
     whenPushSatisfies,
 } from "@atomist/sdm";
-import { disableDeploy, enableDeploy } from "@atomist/sdm/handlers/commands/SetDeployEnablement";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
+import {
+    disableDeploy,
+    enableDeploy,
+} from "@atomist/sdm/handlers/commands/SetDeployEnablement";
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
 import { IsMaven } from "@atomist/sdm/mapping/pushtest/jvm/jvmPushTests";
 import { tagRepo } from "@atomist/sdm/util/github/tagRepo";
@@ -42,10 +45,11 @@ export const EnableSpringBoot = new MessageGoal("enableSpringBoot");
 /**
  * Assemble a machine that suggests the potential to use more SDM features
  */
-export function evangelicalMachine(options: SoftwareDeliveryMachineOptions,
-                                   configuration: Configuration): SoftwareDeliveryMachine {
-    const sdm = createSoftwareDeliveryMachine(
-        {name: "Helpful software delivery machine. You need to be saved.", options, configuration},
+export function evangelicalMachine(configuration: SoftwareDeliveryMachineConfiguration): SoftwareDeliveryMachine {
+    const sdm = createSoftwareDeliveryMachine({
+            name: "Helpful software delivery machine. You need to be saved.",
+            configuration,
+        },
         whenPushSatisfies(IsMaven, HasSpringBootApplicationClass, not(MaterialChangeToJavaRepo))
             .itMeans("No material change to Java")
             .setGoals(ImmaterialChangeToJava),

--- a/src/machines/k8sMachine.ts
+++ b/src/machines/k8sMachine.ts
@@ -14,23 +14,29 @@
  * limitations under the License.
  */
 
-import { Configuration } from "@atomist/automation-client";
 import {
     FromAtomist,
     IsDeployEnabled,
     not,
     ProductionDeploymentGoal,
-    SoftwareDeliveryMachine, SoftwareDeliveryMachineOptions,
+    SoftwareDeliveryMachine,
     StagingDeploymentGoal,
     ToDefaultBranch,
     whenPushSatisfies,
 } from "@atomist/sdm";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import * as build from "@atomist/sdm/dsl/buildDsl";
 import { NoGoals } from "@atomist/sdm/goal/common/commonGoals";
 import { HttpServiceGoals } from "@atomist/sdm/goal/common/httpServiceGoals";
 import { LibraryGoals } from "@atomist/sdm/goal/common/libraryGoals";
-import { NpmBuildGoals, NpmDeployGoals } from "@atomist/sdm/goal/common/npmGoals";
-import { disableDeploy, enableDeploy } from "@atomist/sdm/handlers/commands/SetDeployEnablement";
+import {
+    NpmBuildGoals,
+    NpmDeployGoals,
+} from "@atomist/sdm/goal/common/npmGoals";
+import {
+    disableDeploy,
+    enableDeploy,
+} from "@atomist/sdm/handlers/commands/SetDeployEnablement";
 import { requestDeployToK8s } from "@atomist/sdm/handlers/events/delivery/deploy/k8s/RequestK8sDeploys";
 import { K8sAutomationBuilder } from "@atomist/sdm/internal/delivery/build/k8s/K8AutomationBuilder";
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
@@ -55,11 +61,9 @@ import { LocalDeploymentGoals } from "../parts/localDeploymentGoals";
 import { addJavaSupport } from "../parts/stacks/javaSupport";
 import { addTeamPolicies } from "../parts/team/teamPolicies";
 
-export function k8sMachine(options: SoftwareDeliveryMachineOptions,
-                           configuration: Configuration): SoftwareDeliveryMachine {
+export function k8sMachine(configuration: SoftwareDeliveryMachineConfiguration): SoftwareDeliveryMachine {
     const sdm = createSoftwareDeliveryMachine({
             name: "K8s software delivery machine",
-            options,
             configuration,
         },
         whenPushSatisfies(IsMaven, not(MaterialChangeToJavaRepo))
@@ -102,7 +106,7 @@ export function k8sMachine(options: SoftwareDeliveryMachineOptions,
             disableDeploy,
         )
         .addSupportingEvents(() => NoticeK8sTestDeployCompletion,
-            () => noticeK8sProdDeployCompletion(sdm.options.repoRefResolver))
+            () => noticeK8sProdDeployCompletion(configuration.sdm.repoRefResolver))
         .addEndpointVerificationListeners(
             lookFor200OnEndpointRootGet({
                 retries: 15,

--- a/src/machines/projectCreationMachine.ts
+++ b/src/machines/projectCreationMachine.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import { Configuration } from "@atomist/automation-client";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import {
-    SoftwareDeliveryMachine, SoftwareDeliveryMachineOptions,
-} from "@atomist/sdm";
+import { SoftwareDeliveryMachine } from "@atomist/sdm";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
 import { tagRepo } from "@atomist/sdm/util/github/tagRepo";
 import { nodeTagger } from "@atomist/spring-automation/commands/tag/nodeTagger";
@@ -36,9 +34,11 @@ import {
  * See generatorConfig.ts to customize generation defaults.
  * @return {SoftwareDeliveryMachine}
  */
-export function projectCreationMachine(options: SoftwareDeliveryMachineOptions,
-                                       configuration: Configuration): SoftwareDeliveryMachine {
-    const sdm = createSoftwareDeliveryMachine({name: "Project creation machine", options, configuration});
+export function projectCreationMachine(configuration: SoftwareDeliveryMachineConfiguration): SoftwareDeliveryMachine {
+    const sdm = createSoftwareDeliveryMachine({
+        name: "Project creation machine",
+        configuration,
+    });
 
     sdm.addGenerators(
         springBootGenerator({

--- a/src/machines/staticAnalysisMachine.ts
+++ b/src/machines/staticAnalysisMachine.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { Configuration } from "@atomist/automation-client";
 import { DefaultReviewComment } from "@atomist/automation-client/operations/review/ReviewResult";
 import { saveFromFiles } from "@atomist/automation-client/project/util/projectUtils";
 import {
     Goals,
     ReviewerRegistration,
     ReviewGoal,
-    SoftwareDeliveryMachine, SoftwareDeliveryMachineOptions,
+    SoftwareDeliveryMachine,
     whenPushSatisfies,
 } from "@atomist/sdm";
+import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import { createSoftwareDeliveryMachine } from "@atomist/sdm/machine/machineFactory";
 import { IsJava } from "@atomist/sdm/mapping/pushtest/jvm/jvmPushTests";
 import { CheckstyleSupport } from "../pack/checkstyle/checkstyleSupport";
@@ -34,12 +34,11 @@ import { addDemoEditors } from "../parts/demo/demoEditors";
  * Assemble a machine that performs only static analysis.
  * @return {SoftwareDeliveryMachine}
  */
-export function staticAnalysisMachine(options: SoftwareDeliveryMachineOptions,
-                                      configuration: Configuration): SoftwareDeliveryMachine {
+export function staticAnalysisMachine(configuration: SoftwareDeliveryMachineConfiguration): SoftwareDeliveryMachine {
     const sdm = createSoftwareDeliveryMachine(
         {
             name: "Static analysis SDM",
-            options, configuration,
+            configuration,
         },
         whenPushSatisfies(IsJava, MaterialChangeToJavaRepo)
             .itMeans("Change to Java")

--- a/src/pack/checkstyle/checkstyleSupport.ts
+++ b/src/pack/checkstyle/checkstyleSupport.ts
@@ -15,7 +15,10 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import { ExtensionPack, SoftwareDeliveryMachine } from "@atomist/sdm";
+import {
+    ExtensionPack,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
 import { checkstyleReviewerRegistration } from "@atomist/sdm/pack/checkstyle/checkstyleReviewer";
 
 export interface CheckstyleSupportOptions {

--- a/src/pack/cloud-readiness/cloudReadinessIssueManager.ts
+++ b/src/pack/cloud-readiness/cloudReadinessIssueManager.ts
@@ -16,13 +16,16 @@
 
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { deepLink } from "@atomist/automation-client/util/gitHub";
-import { ImportDotStarCategory } from "../../blueprint/code/review/java/importDotStarReviewer";
-import { CommentsFormatter, singleIssueManagingReviewListener } from "../../blueprint/issue/issueManagingReviewListeners";
 
 import { ReviewListener } from "@atomist/sdm";
 import * as _ from "lodash";
 import { ImportFileIoCategory } from "../../blueprint/code/review/java/fileIoImportReviewer";
+import { ImportDotStarCategory } from "../../blueprint/code/review/java/importDotStarReviewer";
 import { HardcodePropertyCategory } from "../../blueprint/code/review/java/spring/hardcodedPropertyReviewer";
+import {
+    CommentsFormatter,
+    singleIssueManagingReviewListener,
+} from "../../blueprint/issue/issueManagingReviewListeners";
 
 const CloudReadinessIssueTitle = "Service Not Yet Cloud Native";
 const CloudReadinessReviewCommentCategories = [

--- a/src/pack/codemetrics/codeMetrics.ts
+++ b/src/pack/codemetrics/codeMetrics.ts
@@ -2,12 +2,16 @@ import { logger } from "@atomist/automation-client";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import {
     ExtensionPack,
-    FingerprinterRegistration, FingerprintListener,
+    FingerprinterRegistration,
+    FingerprintListener,
     PushTest,
     SoftwareDeliveryMachine,
 } from "@atomist/sdm";
 import { TypedFingerprint } from "@atomist/sdm/code/fingerprint/TypedFingerprint";
-import { CodeStats, reportForLanguages } from "@atomist/sdm/pack/sloc/slocReport";
+import {
+    CodeStats,
+    reportForLanguages,
+} from "@atomist/sdm/pack/sloc/slocReport";
 
 const CodeMetricsFingerprintName = "CodeMetrics";
 

--- a/src/pack/demo/demoPolicies.ts
+++ b/src/pack/demo/demoPolicies.ts
@@ -15,7 +15,12 @@
  */
 
 import { Issue } from "@atomist/automation-client/util/gitHub";
-import { editorAutofixRegistration, ExtensionPack, hasFile, not } from "@atomist/sdm";
+import {
+    editorAutofixRegistration,
+    ExtensionPack,
+    hasFile,
+    not,
+} from "@atomist/sdm";
 import { updateIssue } from "@atomist/sdm/util/github/ghub";
 import axios from "axios";
 
@@ -29,7 +34,7 @@ export const DemoPolicies: ExtensionPack = {
     version: "0.1.0",
     configure: sdm => {
         sdm
-        // Close all newly created issues
+            // Close all newly created issues
             .addCommands({
                 name: "helloworld",
                 listener: async cli => cli.addressChannels("Hello world"),

--- a/src/pack/node/generators/NodeProjectCreationParameters.ts
+++ b/src/pack/node/generators/NodeProjectCreationParameters.ts
@@ -19,7 +19,10 @@ import { Parameter } from "@atomist/automation-client";
 import { Parameters } from "@atomist/automation-client/decorators";
 import { GitHubRepoCreationParameters } from "@atomist/automation-client/operations/generate/GitHubRepoCreationParameters";
 import { NewRepoCreationParameters } from "@atomist/automation-client/operations/generate/NewRepoCreationParameters";
-import { GeneratorConfig, SeedDrivenGeneratorParametersSupport } from "@atomist/sdm";
+import {
+    GeneratorConfig,
+    SeedDrivenGeneratorParametersSupport,
+} from "@atomist/sdm";
 
 /**
  * Parameters for creating a Node project.

--- a/src/pack/node/generators/nodeGenerator.ts
+++ b/src/pack/node/generators/nodeGenerator.ts
@@ -17,7 +17,10 @@
 import { AnyProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { chainEditors } from "@atomist/automation-client/operations/edit/projectEditorOps";
 import { GeneratorCommandDetails } from "@atomist/automation-client/operations/generate/generatorToCommand";
-import { GeneratorConfig, GeneratorRegistration } from "@atomist/sdm";
+import {
+    GeneratorConfig,
+    GeneratorRegistration,
+} from "@atomist/sdm";
 import { updateReadmeTitle } from "../../../commands/editors/updateReadmeTitle";
 import { updatePackageJsonIdentification } from "../editors/updatePackageJsonIdentification";
 import { NodeProjectCreationParameters } from "./NodeProjectCreationParameters";

--- a/src/pack/node/nodeSupport.ts
+++ b/src/pack/node/nodeSupport.ts
@@ -15,7 +15,17 @@
  */
 
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import { ExtensionPack, hasFile, SoftwareDeliveryMachine, ToDefaultBranch } from "@atomist/sdm";
+import {
+    ExtensionPack,
+    hasFile,
+    SoftwareDeliveryMachine,
+    ToDefaultBranch,
+} from "@atomist/sdm";
+
+import * as build from "@atomist/sdm/dsl/buildDsl";
+
+import { nodeBuilder } from "@atomist/sdm/internal/delivery/build/local/npm/npmBuilder";
+import { IsNode } from "@atomist/sdm/mapping/pushtest/node/nodePushTests";
 import { PackageLockFingerprinter } from "@atomist/sdm/pack/node/PackageLockFingerprinter";
 import { tslintFix } from "@atomist/sdm/pack/node/tslint";
 import { tagRepo } from "@atomist/sdm/util/github/tagRepo";
@@ -26,11 +36,6 @@ import { CommonTypeScriptErrors } from "../../parts/team/commonTypeScriptErrors"
 import { DontImportOwnIndex } from "../../parts/team/dontImportOwnIndex";
 import { AddBuildScript } from "./autofix/addBuildScript";
 import { nodeGenerator } from "./generators/nodeGenerator";
-
-import { nodeBuilder } from "@atomist/sdm/internal/delivery/build/local/npm/npmBuilder";
-import { IsNode } from "@atomist/sdm/mapping/pushtest/node/nodePushTests";
-
-import * as build from "@atomist/sdm/dsl/buildDsl";
 
 /**
  * Add configuration common to Node SDMs, wherever they deploy
@@ -80,16 +85,16 @@ export const NodeSupport: ExtensionPack = {
             .addBuildRules(
                 build.when(IsNode, ToDefaultBranch, hasPackageLock)
                     .itMeans("npm run build")
-                    .set(nodeBuilder(sdm.options.projectLoader, "npm ci", "npm run build")),
+                    .set(nodeBuilder(sdm.configuration.sdm.projectLoader, "npm ci", "npm run build")),
                 build.when(IsNode, hasPackageLock)
                     .itMeans("npm run compile")
-                    .set(nodeBuilder(sdm.options.projectLoader, "npm ci", "npm run compile")),
+                    .set(nodeBuilder(sdm.configuration.sdm.projectLoader, "npm ci", "npm run compile")),
                 build.when(IsNode, ToDefaultBranch)
                     .itMeans("npm run build - no package lock")
-                    .set(nodeBuilder(sdm.options.projectLoader, "npm i", "npm run build")),
+                    .set(nodeBuilder(sdm.configuration.sdm.projectLoader, "npm i", "npm run build")),
                 build.when(IsNode)
                     .itMeans("npm run compile - no package lock")
-                    .set(nodeBuilder(sdm.options.projectLoader, "npm i", "npm run compile")));
+                    .set(nodeBuilder(sdm.configuration.sdm.projectLoader, "npm i", "npm run compile")));
 
     },
 };

--- a/src/pack/node/pushtest/materialChangeToNodeRepo.ts
+++ b/src/pack/node/pushtest/materialChangeToNodeRepo.ts
@@ -15,7 +15,10 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import { PushTest, pushTest } from "@atomist/sdm";
+import {
+    PushTest,
+    pushTest,
+} from "@atomist/sdm";
 import {
     anyFileChangedSuchThat,
     anyFileChangedWithExtension,

--- a/src/pack/owasp/OWASPDependencyCheckArtifactListener.ts
+++ b/src/pack/owasp/OWASPDependencyCheckArtifactListener.ts
@@ -1,4 +1,7 @@
-import { ArtifactListenerRegistration, ToDefaultBranch } from "@atomist/sdm";
+import {
+    ArtifactListenerRegistration,
+    ToDefaultBranch,
+} from "@atomist/sdm";
 import { LoggingProgressLog } from "@atomist/sdm/api-helper/log/LoggingProgressLog";
 import {
     asSpawnCommand,

--- a/src/pack/sentry/addSentryEditor.ts
+++ b/src/pack/sentry/addSentryEditor.ts
@@ -1,14 +1,13 @@
-import { ProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
-import { chainEditors } from "@atomist/automation-client/operations/edit/projectEditorOps";
-import { EditorRegistration } from "@atomist/sdm";
-import { appendOrCreateFileContent } from "@atomist/sdm/util/project/appendOrCreate";
-import { copyFileFromUrl } from "@atomist/sdm/util/project/fileCopy";
-import { addDependencyEditor } from "@atomist/spring-automation/commands/editor/maven/addDependencyEditor";
-
 import { Parameter } from "@atomist/automation-client";
 import { Parameters } from "@atomist/automation-client/decorators";
 import { PullRequest } from "@atomist/automation-client/operations/edit/editModes";
+import { ProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
+import { chainEditors } from "@atomist/automation-client/operations/edit/projectEditorOps";
+import { EditorRegistration } from "@atomist/sdm";
 import { VersionedArtifact } from "@atomist/sdm/internal/delivery/build/local/maven/VersionedArtifact";
+import { appendOrCreateFileContent } from "@atomist/sdm/util/project/appendOrCreate";
+import { copyFileFromUrl } from "@atomist/sdm/util/project/fileCopy";
+import { addDependencyEditor } from "@atomist/spring-automation/commands/editor/maven/addDependencyEditor";
 
 const SentryDependency: VersionedArtifact = {
     group: "io.sentry",

--- a/src/pack/sonarqube/sonarQubeReviewer.ts
+++ b/src/pack/sonarqube/sonarQubeReviewer.ts
@@ -1,7 +1,13 @@
 import { logger } from "@atomist/automation-client";
-import { ReviewerRegistration, ToDefaultBranch } from "@atomist/sdm";
+import {
+    ReviewerRegistration,
+    ToDefaultBranch,
+} from "@atomist/sdm";
 import { StringCapturingProgressLog } from "@atomist/sdm/api-helper/log/StringCapturingProgressLog";
-import { asSpawnCommand, spawnAndWatch } from "@atomist/sdm/util/misc/spawned";
+import {
+    asSpawnCommand,
+    spawnAndWatch,
+} from "@atomist/sdm/util/misc/spawned";
 
 export interface SonarCubeOptions {
     url: string;

--- a/src/pack/sonarqube/sonarQubeSupport.ts
+++ b/src/pack/sonarqube/sonarQubeSupport.ts
@@ -1,5 +1,8 @@
 import { ExtensionPack } from "@atomist/sdm";
-import { SonarCubeOptions, sonarQubeReviewer } from "./sonarQubeReviewer";
+import {
+    SonarCubeOptions,
+    sonarQubeReviewer,
+} from "./sonarQubeReviewer";
 
 export const SonarQubeSupport: ExtensionPack = {
     name: "SonarQube",

--- a/src/pack/spring/editors/tryToUpgradeSpringBootVersion.ts
+++ b/src/pack/spring/editors/tryToUpgradeSpringBootVersion.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
-import { Parameter, Parameters } from "@atomist/automation-client";
-import { EditModeSuggestion, EditorRegistration } from "@atomist/sdm";
+import {
+    Parameter,
+    Parameters,
+} from "@atomist/automation-client";
+import {
+    EditModeSuggestion,
+    EditorRegistration,
+} from "@atomist/sdm";
 import { setSpringBootVersionEditor } from "@atomist/spring-automation/commands/editor/spring/setSpringBootVersionEditor";
 
 @Parameters()

--- a/src/pack/spring/generators/springBootGenerator.ts
+++ b/src/pack/spring/generators/springBootGenerator.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
+import { SimpleProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { chainEditors } from "@atomist/automation-client/operations/edit/projectEditorOps";
 import { GeneratorCommandDetails } from "@atomist/automation-client/operations/generate/generatorToCommand";
 import * as utils from "@atomist/automation-client/project/util/projectUtils";
-
-import { SimpleProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { GeneratorRegistration } from "@atomist/sdm";
 import { JavaGeneratorConfig } from "../../java/support/JavaGeneratorConfig";
 import { SpringProjectCreationParameters } from "./SpringProjectCreationParameters";

--- a/src/pack/spring/pushtest/materialChangeToJavaRepo.ts
+++ b/src/pack/spring/pushtest/materialChangeToJavaRepo.ts
@@ -15,8 +15,14 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import { PushTest, pushTest } from "@atomist/sdm";
-import { anyFileChangedWithExtension, filesChangedSince } from "@atomist/sdm/util/git/filesChangedSince";
+import {
+    PushTest,
+    pushTest,
+} from "@atomist/sdm";
+import {
+    anyFileChangedWithExtension,
+    filesChangedSince,
+} from "@atomist/sdm/util/git/filesChangedSince";
 
 import * as _ from "lodash";
 

--- a/src/pack/spring/pushtest/springPushTests.ts
+++ b/src/pack/spring/pushtest/springPushTests.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { predicatePushTest, PredicatePushTest } from "@atomist/sdm";
+import {
+    predicatePushTest,
+    PredicatePushTest,
+} from "@atomist/sdm";
 import { SpringBootProjectStructure } from "@atomist/spring-automation/commands/generator/spring/SpringBootProjectStructure";
 
 /**

--- a/src/pack/spring/springSupport.ts
+++ b/src/pack/spring/springSupport.ts
@@ -15,9 +15,15 @@
  */
 
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import { ExtensionPack, LocalDeploymentGoal } from "@atomist/sdm";
+import {
+    ExtensionPack,
+    LocalDeploymentGoal,
+} from "@atomist/sdm";
 import * as deploy from "@atomist/sdm/dsl/deployDsl";
-import { LocalEndpointGoal, LocalUndeploymentGoal } from "@atomist/sdm/goal/common/commonGoals";
+import {
+    LocalEndpointGoal,
+    LocalUndeploymentGoal,
+} from "@atomist/sdm/goal/common/commonGoals";
 import { listLocalDeploys } from "@atomist/sdm/handlers/commands/listLocalDeploys";
 import { ManagedDeploymentTargeter } from "@atomist/sdm/internal/delivery/deploy/local/ManagedDeployments";
 import { IsMaven } from "@atomist/sdm/mapping/pushtest/jvm/jvmPushTests";
@@ -40,7 +46,7 @@ export const SpringSupport: ExtensionPack = {
                     .deployTo(LocalDeploymentGoal, LocalEndpointGoal, LocalUndeploymentGoal)
                     .using(
                         {
-                            deployer: mavenSourceDeployer(sdm.options.projectLoader),
+                            deployer: mavenSourceDeployer(sdm.configuration.sdm.projectLoader),
                             targeter: ManagedDeploymentTargeter,
                         },
                     ))

--- a/src/parts/DefaultCredentialsResolver.ts
+++ b/src/parts/DefaultCredentialsResolver.ts
@@ -1,4 +1,3 @@
-
 /*
  * Copyright © 2018 Atomist, Inc.
  *

--- a/src/parts/demo/demoEditors.ts
+++ b/src/parts/demo/demoEditors.ts
@@ -16,7 +16,10 @@
 
 import { SoftwareDeliveryMachine } from "@atomist/sdm";
 import { AffirmationEditor } from "../../commands/editors/demo/affirmationEditor";
-import { BreakJavaBuildEditor, UnbreakJavaBuildEditor } from "../../commands/editors/demo/breakJavaBuild";
+import {
+    BreakJavaBuildEditor,
+    UnbreakJavaBuildEditor,
+} from "../../commands/editors/demo/breakJavaBuild";
 import {
     BreakNodeBuildEditor,
     UnbreakNodeBuildEditor,

--- a/src/parts/localDeploymentGoals.ts
+++ b/src/parts/localDeploymentGoals.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Goals, LocalDeploymentGoal, PushReactionGoal } from "@atomist/sdm";
+import {
+    Goals,
+    LocalDeploymentGoal,
+    PushReactionGoal,
+} from "@atomist/sdm";
 import { LocalEndpointGoal } from "@atomist/sdm/goal/common/commonGoals";
 
 export const LocalDeploymentGoals = new Goals(

--- a/src/parts/team/teamPolicies.ts
+++ b/src/parts/team/teamPolicies.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { logger } from "@atomist/automation-client";
-import { FingerprintListener, SoftwareDeliveryMachine } from "@atomist/sdm";
+import {
+    FingerprintListener,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
 import { slackReviewListener } from "@atomist/sdm/code/review/slackReviewListener";
 import { GraphGoalsToSlack } from "@atomist/sdm/goal/graph/graphGoalsToSlack";
 import { DryRunEditing } from "@atomist/sdm/pack/dry-run/dryRunEditorSupport";
@@ -58,10 +60,7 @@ export function addTeamPolicies(sdm: SoftwareDeliveryMachine) {
     );
 
     if (sdm.configuration.sdm.sonar && sdm.configuration.sdm.sonar.enabled) {
-        logger.info("Enabling SonarQube integration");
         sdm.addExtensionPacks(SonarQubeSupport);
-    } else {
-        logger.info("SonarQube integration not enabled");
     }
 
     const pub: FingerprintListener = async fp => {

--- a/src/util/logzio.ts
+++ b/src/util/logzio.ts
@@ -31,7 +31,10 @@ import {
     AutomationEventListener,
     AutomationEventListenerSupport,
 } from "@atomist/automation-client/server/AutomationEventListener";
-import { Destination, MessageOptions } from "@atomist/automation-client/spi/message/MessageClient";
+import {
+    Destination,
+    MessageOptions,
+} from "@atomist/automation-client/spi/message/MessageClient";
 
 import * as _ from "lodash";
 import { createLogger } from "logzio-nodejs";


### PR DESCRIPTION
With this we can now specify `SdmOptions` inside the client's `configuration`:

```
function machineMaker(config: SoftwareDeliveryMachineConfiguration) {
    return additiveCloudFoundryMachine(config);
}

export const configuration: Configuration = {
    postProcessors: [
        configureSdm(machineMaker),
    ],
    sdm: {
        artifactStore: new SomeOtherArtifactStore(),
    }
};
```